### PR TITLE
On MSVC, if DenseSet is forward declared, the code fails if we don't …

### DIFF
--- a/llvm/include/llvm/ADT/DenseSet.h
+++ b/llvm/include/llvm/ADT/DenseSet.h
@@ -130,6 +130,7 @@ public:
 
   class ConstIterator {
     typename MapTy::const_iterator I;
+    template <typename ValueT, typename ValueInfoT>
     friend class DenseSet;
     friend class Iterator;
 


### PR DESCRIPTION
…add "template"